### PR TITLE
Remove filter for Google cookies

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -47,8 +47,7 @@ var getAllCookies= function(params) {
 
   Promise.all(combinedPromises).then(function(combinedResponses) {
     combinedResponses= combinedResponses
-                        .reduce(function(prev, cur) { return prev.concat(cur); }, [])  // flatten multuple responses into single array
-                        .filter(function(cookieResponse) { return cookieResponse.domain.indexOf("google.") === -1; });  // filter Google top level deomains. This will also filter SAML IdPs that fall undewr this pattern but it is worth the resulting code simplification
+      .reduce(function (prev, cur) { return prev.concat(cur); }, []);  // flatten multuple responses into single array
 
     params.callback({ cookies: combinedResponses });
   });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML SSO for Chrome Apps",
   "description": "Helper extension for admins to configure SAML SSO for Chrome apps.",
-  "version": "1.1",
+  "version": "1.2",
   "manifest_version": 3,
   "storage": {
     "managed_schema": "schema.json"

--- a/test/manifest.json
+++ b/test/manifest.json
@@ -1,11 +1,13 @@
 {
   "name": "SAML SSO Test Runner Extension",
   "description": "Test extension with HTML and JS runner",
-  "version": "0.1",
-  "manifest_version": 2,
-    "permissions": [
+  "version": "0.2",
+  "manifest_version": 3,
+  "permissions": [
     "cookies",
-    "storage",
+    "storage"
+  ],
+  "host_permissions": [
     "https://*/*"
   ]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -187,25 +187,6 @@
     });
   };
 
-  var testGoogleDomainCookiesAreFilteredOut= function(pass, fail) {
-        var params= TestUtils.aParams({
-      "whitelist": [{
-          "appId": chrome.runtime.id,
-          "domain": "google.com"
-        }]
-    });
-
-    TestUtils.setCookie("https://mail.google.com", "google.com", "Name 1", "value1")
-    .then(function() { return TestUtils.setCookie("https://docs.google.com", "google.com", "Name 2", "value2"); })
-    .then(function() { return TestUtils.setCookie("https://google.com", "google.com", "Name 3", "value3"); })
-    .then(function() { return TestUtils.getCookies(params); })
-    .then(function(response) {
-      TestUtils.assert(response.cookies.length === 0);
-
-      pass("Passed: API filters out Google-based domains");
-    });
-  };
-
   document.getElementById("startBtn").addEventListener("click", function() {
     Promise.resolve("Start Tests")
       .then(TestUtils.testCase(testBadMessageReturnsErrorJson))
@@ -217,7 +198,6 @@
       .then(TestUtils.testCase(testNoDomainInFilterReturnsNoCookies))
       .then(TestUtils.testCase(testSecondaryFilteringByNameReturnsScopedCookies))
       .then(TestUtils.testCase(testSecondaryFilteringByPathReturnsScopedCookies))
-      .then(TestUtils.testCase(testGoogleDomainCookiesAreFilteredOut))
       .then(function() { TestUtils.displayResult("All Tests Passed!"); });
   });
 })();


### PR DESCRIPTION
We want to allow other apps to use Google cookies for SSO.

This wasn't really a security measure to begin with as anyone could write a similar extension that does read out all cookies without filter (like we do now).

The existing test (which will be removed) was passing, but didn't actually test anything since it failed to add the cookies for the google.com domain due to missing host permissions anyway. So even without the filtering, the test was passing.