### PR TITLE
Add http://*/* host permission to be able to access non-secure cookies

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
     "storage"
   ],
   "host_permissions": [
-    "https://*/*"
+    "https://*/*",
+    "http://*/*"
   ],
   "background": {
     "service_worker": "background.js"

--- a/test/manifest.json
+++ b/test/manifest.json
@@ -8,6 +8,7 @@
     "storage"
   ],
   "host_permissions": [
-    "https://*/*"
+    "https://*/*",
+    "http://*/*"
   ]
 }

--- a/test/manifest.json
+++ b/test/manifest.json
@@ -8,7 +8,6 @@
     "storage"
   ],
   "host_permissions": [
-    "https://*/*",
-    "http://*/*"
+    "*://*/*"
   ]
 }

--- a/test/test.js
+++ b/test/test.js
@@ -73,11 +73,27 @@
     .then(function() { return TestUtils.setCookie("https://some.otherurl.com", "otherurl.com", "Other Name", "othervalue"); })
     .then(function() { return TestUtils.getCookies(params); })
     .then(function(response) {
-      TestUtils.assert(response.cookies.length === 2);
-      TestUtils.assert(response.cookies[0].value === "value1");
-      TestUtils.assert(response.cookies[1].value === "value2");
+      TestUtils.assertCookieValues(response.cookies, ["value1", "value2"]);
 
       pass("Passed: Domain filter returns proper cookies with single domain filter");
+    });
+  };
+
+  var testReturnsUnsecureAndSecureCookies= function(pass, fail) {
+    var params= TestUtils.aParams({
+      "whitelist": [{
+          "appId": chrome.runtime.id,
+          "domain": "mytesturl.com"
+        }]
+    });
+
+    TestUtils.setCookie("https://test.mytesturl.com", "mytesturl.com", "Name 1", "value1", true)
+    .then(function() { return TestUtils.setCookie("https://test.mytesturl.com", "mytesturl.com", "Name 2", "value2", false); })
+    .then(function() { return TestUtils.getCookies(params); })
+    .then(function(response) {
+      TestUtils.assertCookieValues(response.cookies, ["value1", "value2"]);
+
+      pass("Passed: Returns both secure and unsecure cookies");
     });
   };
 
@@ -94,9 +110,7 @@
     .then(function() { return TestUtils.setCookie("https://some.otherurl.com", "otherurl.com", "Other Name", "othervalue"); })
     .then(function() { return TestUtils.getCookies(params); })
     .then(function(response) {
-      TestUtils.assert(response.cookies.length === 2);
-      TestUtils.assert(response.cookies[0].value === "value1");
-      TestUtils.assert(response.cookies[1].value === "value2");
+      TestUtils.assertCookieValues(response.cookies, ["value1", "value2"]);
 
       pass("Passed: Domain filter returns proper cookies with single domain filter prefixed with dot");
     });
@@ -120,10 +134,7 @@
     .then(function() { return TestUtils.setCookie("https://wrongotherurl.com", "wrongotherurl.com", "Wrong Name", "wrong"); })
     .then(function() { return TestUtils.getCookies(params); })
     .then(function(response) {
-      TestUtils.assert(response.cookies.length === 3);
-      TestUtils.assert(response.cookies[0].value === "value1");
-      TestUtils.assert(response.cookies[1].value === "value2");
-      TestUtils.assert(response.cookies[2].value === "othervalue");
+      TestUtils.assertCookieValues(response.cookies, ["value1", "value2", "othervalue"]);
 
       pass("Passed: Domain filter returns proper cookies with multiple domain filters");
     });
@@ -193,6 +204,7 @@
       .then(TestUtils.testCase(testNoAppIdReturnsNoCookies))
       .then(TestUtils.testCase(testAppIdNotInWhitelistReturnsNoCookies))
       .then(TestUtils.testCase(testSingleDomainFilterReturnsMultipleCookies))
+      .then(TestUtils.testCase(testReturnsUnsecureAndSecureCookies))
       .then(TestUtils.testCase(testSingleDomainFilterWithPrefixedDotReturnsMultipleCookies))
       .then(TestUtils.testCase(testMultipleDomainFilterReturnsMultipleCookies))
       .then(TestUtils.testCase(testNoDomainInFilterReturnsNoCookies))

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -52,6 +52,17 @@ TestUtils.assert= function(condition, msg) {
   if (!condition) throw new Error(msg);
 };
 
+TestUtils.assertCookieValues= function(cookies, values) {
+  const sortedCookies = cookies.map(cookie => cookie.value).sort();
+  const sortedValues = [... values].sort();
+
+  TestUtils.assert(sortedCookies.length === sortedValues.length, `Expected the following cookie values: ${JSON.stringify(sortedValues)}, but got ${JSON.stringify(sortedCookies)}.`);
+
+  for (let i = 0; i < sortedCookies.length; ++i) {
+    TestUtils.assert(sortedCookies[i] === sortedValues[i], `Error while comparing cookie ${i}: ${sortedCookies[i]} != ${sortedValues[i]}`);
+  }
+};
+
 TestUtils.testCase= function(testFn) {
   return function() {
     console.log("Started test case"); 


### PR DESCRIPTION
Without this host permission, the extension cannot access cookies not marked as "secure".

Bugs (internal): https://crbug.com/1497385, https://issuetracker.google.com/307706348