### PR TITLE
Make the extension externally connectable by any IWA.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -21,5 +21,8 @@
     "16": "icon16.png",
     "48": "icon48.png",
     "128": "icon128.png" 
+  },
+  "externally_connectable": {
+    "matches": ["isolated-app://*/*"]
   }
 }


### PR DESCRIPTION
This change is necessary to unblock the SAML SSO extension for Isolated Web Apps.

Here's more info about the `externally_connectable` just in case:
https://developer.chrome.com/docs/extensions/reference/manifest/externally-connectable