### PR TITLE
Bump version in the manifest.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML SSO for Chrome Apps",
   "description": "Helper extension for admins to configure SAML SSO for Chrome apps.",
-  "version": "1.3",
+  "version": "1.4",
   "manifest_version": 3,
   "storage": {
     "managed_schema": "schema.json"


### PR DESCRIPTION
This is needed to actually publish the updated package to the chrome web store.