### PR TITLE
Let Isolated Web Apps IDs be whitelisted to connect as well.

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -53,6 +53,11 @@ var getAllCookies= function(params) {
   });
 };
 
+var isolatedWebAppId = function(origin) {
+  var match = origin.match(/^isolated-app:\/\/(.+)$/);
+  return match && match[1];
+};
+
 chrome.runtime.onMessageExternal.addListener(
   function(request, sender, sendResponse) {
     request= request || {};
@@ -60,7 +65,7 @@ chrome.runtime.onMessageExternal.addListener(
       chrome.storage.managed.get(function(configuration) {
         if (!configuration.whitelist) configuration.whitelist= [];
         getAllCookies({
-          appId: sender.id,
+          appId: sender.id || isolatedWebAppId(sender.origin),
           configuration: configuration,
           callback: sendResponse
         });

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "SAML SSO for Chrome Apps",
   "description": "Helper extension for admins to configure SAML SSO for Chrome apps.",
-  "version": "1.5",
+  "version": "1.6",
   "manifest_version": 3,
   "storage": {
     "managed_schema": "schema.json"


### PR DESCRIPTION
Grab the IWA ID from its origin and check that against the whitelisted app ids.